### PR TITLE
Build script improvments

### DIFF
--- a/README
+++ b/README
@@ -30,5 +30,4 @@ Installation
 To build and install:
 
 1. untar the archive
-2. cd build
-3. sudo sh install.sh
+2. sudo sh install.sh

--- a/build/install.sh
+++ b/build/install.sh
@@ -17,11 +17,11 @@ make all
 echo
 echo "*    Install...            *"
 echo
-if test -f /etc/debian_version; then
+if which sudo &>/dev/null; then
+	sudo make install
+else
 	echo "Enter root password"
 	su -c "make install"
-else
-	sudo make install
 fi
 
 echo

--- a/install.sh
+++ b/install.sh
@@ -8,18 +8,18 @@ if [[ -z "$BUILDDIR" ]] ; then
     BUILDDIR="build"
 fi
 
-mkdir -p $BUILDDIR
-cd $BUILDDIR
+mkdir -p $BUILDDIR || exit 1
+cd $BUILDDIR || exit 1
 
 echo
 echo "*     Configure...        *"
 echo
-cmake -DCMAKE_INSTALL_PREFIX=`kde4-config --prefix` ..
+cmake -DCMAKE_INSTALL_PREFIX=`kde4-config --prefix` .. || exit 1
 
 echo
 echo "*    Compile...           *"
 echo
-make all
+make all || exit 1
 
 echo
 echo "*    Install...            *"

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,13 @@
 #05 Aug 2012
 #This script was written and tested on openSuSe 12.1
 
+if [[ -z "$BUILDDIR" ]] ; then
+    BUILDDIR="build"
+fi
+
+mkdir -p $BUILDDIR
+cd $BUILDDIR
+
 echo
 echo "*     Configure...        *"
 echo


### PR DESCRIPTION
Made some small improvements to the build script:
- Moved it out side the build directory.  
  This makes it easier to delete the build directory to start a new clean build.
- Removes the assumption that sudo exists on non debian systems.  
  It now checks if sudo exists and run it falling back to su if not.
- Stops the script if one of the stages fails.  
  This will stop the script doing something bad/unexpected if one of the steps fails.
