### PR TITLE
Fixes a crash when closing the widget

### DIFF
--- a/src/activitymanager.cpp
+++ b/src/activitymanager.cpp
@@ -30,13 +30,12 @@
 
 
 ActivityManager::ActivityManager(QObject *parent) :
-    QObject(parent)
+    QObject(parent), m_plShowWidgets(0), m_activitiesCtrl(0)
 {
     m_activitiesCtrl = new KActivities::Controller(this);
     m_timer = new QTimer(this);
     m_timerPhase = 0;
     m_unlockWidgetsText = "";
-
 }
 
 ActivityManager::~ActivityManager()

--- a/src/plugins/pluginshowwidgets.cpp
+++ b/src/plugins/pluginshowwidgets.cpp
@@ -154,17 +154,13 @@ Plasma::Containment *PluginShowWidgets::getContainment(QString actId)
     return 0;
 }
 
-
 void PluginShowWidgets::showWidgetsExplorer(QString actId)
 {
     Plasma::Containment *currentContainment = getContainment(actId);
-    if(currentContainment->view()){
-
+    if(currentContainment && currentContainment->view()){
         currentContainment->view()->metaObject()->invokeMethod(currentContainment->view(),
                                                                "showWidgetExplorer");
-
     }
-
 }
 
 void PluginShowWidgets::execute(QString actid)


### PR DESCRIPTION
This occured some times if the qml code had an error or could not be
found.

(sorry for the frequent pull requests, but I think this is better the letting them pile up as it would be harder to merge them and lets us work of a more stable base)
